### PR TITLE
Bugfix: Memoize clock interval to prevent unmanaged intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# editors
+.idea/

--- a/components/clock/widget.tsx
+++ b/components/clock/widget.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type Props = {};
 
@@ -8,7 +8,7 @@ function ClockWidget({}: Props) {
         hours: new Date().getHours(),
         minutes: new Date().getMinutes().toString(),
     });
-    const date = setInterval(() => {
+    const date = useMemo(() => setInterval(() => {
         const date = new Date();
         const hours = date.getHours();
         const minutes = date.getMinutes();
@@ -17,7 +17,14 @@ function ClockWidget({}: Props) {
             hours,
             minutes: minutes < 10 ? `0${minutes}` : `${minutes}`,
         });
-    }, 1000);
+    }, 1000), []);
+
+    useEffect(() => {
+        return () => {
+            clearInterval(date);
+        };
+    }, [date])
+
     return (
         <Card
             id="clock-widget"


### PR DESCRIPTION
- Only one interval is created when the component is mounted
- The interval is cleaned when the component is unmounted